### PR TITLE
PBC-1656: Add schema file validator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+- Developer(s):
+
+- Ticket: URL_HERE
+
+- Release Group:
+
+#### Release Table
+
+| Module     | Release Type      | Constraint Updates |
+|:-----------|:------------------|:-------------------|
+| ModuleName | major/minor/patch |                    |
+
+-----------------------------------------
+
+#### Module TouchedModuleName
+
+##### Change log
+
+### Bugfixes
+- List your changes or remove.
+
+### Improvements
+- List your changes or remove.
+
+### Removed
+- List your changes or remove.

--- a/architector.php
+++ b/architector.php
@@ -11,6 +11,7 @@ use Rector\Core\Configuration\Option;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\EarlyReturn\Rector\If_\ChangeAndIfToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector;
 use Rector\EarlyReturn\Rector\Return_\ReturnBinaryAndToEarlyReturnRector;
@@ -35,5 +36,6 @@ return static function (RectorConfig $rectorConfig) {
         ReturnBinaryAndToEarlyReturnRector::class,
         SimplifyUselessVariableRector::class,
         TypedPropertyRector::class,
+        RemoveUselessVarTagRector::class
     ]);
 };

--- a/src/SprykerSdk/AsyncApi/AsyncApi/Cli/AsyncApiCli.php
+++ b/src/SprykerSdk/AsyncApi/AsyncApi/Cli/AsyncApiCli.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\AsyncApi\AsyncApi\Cli;
+
+use SprykerSdk\AsyncApi\AsyncApiConfig;
+use SprykerSdk\AsyncApi\Message\AsyncApiError;
+use SprykerSdk\AsyncApi\Message\AsyncApiInfo;
+use SprykerSdk\AsyncApi\Message\MessageBuilderInterface;
+use Symfony\Component\Process\Process;
+use Transfer\ValidateResponseTransfer;
+
+class AsyncApiCli implements AsyncApiCliInterface
+{
+    /**
+     * @var string
+     */
+    protected const ASYNCAPI_CLI = 'asyncapi';
+
+    /**
+     * @var string
+     */
+    protected const ASYNCAPI_CLI_VALIDATE_COMMAND = 'validate';
+
+    /**
+     * @var string
+     */
+    protected const ASYNCAPI_CLI_VERSION = '--version';
+
+    /**
+     * @var \SprykerSdk\AsyncApi\AsyncApiConfig
+     */
+    protected AsyncApiConfig $config;
+
+    /**
+     * @var \SprykerSdk\AsyncApi\Message\MessageBuilderInterface
+     */
+    protected MessageBuilderInterface $messageBuilder;
+
+    /**
+     * @param \SprykerSdk\AsyncApi\AsyncApiConfig $config
+     * @param \SprykerSdk\AsyncApi\Message\MessageBuilderInterface $messageBuilder
+     */
+    public function __construct(AsyncApiConfig $config, MessageBuilderInterface $messageBuilder)
+    {
+        $this->config = $config;
+        $this->messageBuilder = $messageBuilder;
+    }
+
+    /**
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param string $asyncApiFilePath
+     *
+     * @return \Transfer\ValidateResponseTransfer
+     */
+    public function validate(ValidateResponseTransfer $validateResponseTransfer, string $asyncApiFilePath): ValidateResponseTransfer
+    {
+        if (!$this->isCliInstalled()) {
+            $validateResponseTransfer->addMessage($this->messageBuilder->buildMessage(
+                AsyncApiInfo::asyncApiCliNotFound(),
+            ));
+
+            return $validateResponseTransfer;
+        }
+
+        if (!$this->runProcess([static::ASYNCAPI_CLI, static::ASYNCAPI_CLI_VALIDATE_COMMAND, $asyncApiFilePath])) {
+            $validateResponseTransfer->addError($this->messageBuilder->buildMessage(
+                AsyncApiError::asyncApiCliValidationFailed($asyncApiFilePath),
+            ));
+
+            return $validateResponseTransfer;
+        }
+
+        return $validateResponseTransfer;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isCliInstalled(): bool
+    {
+        if (!$this->runProcess([static::ASYNCAPI_CLI, static::ASYNCAPI_CLI_VERSION])) {
+            $this->triggerError('The AsyncAPI validator must be installed starting from the next major version 1.0.0. Not having the validator installed will mark the validation failed.');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array $command
+     *
+     * @return bool
+     */
+    protected function runProcess(array $command): bool
+    {
+        $process = new Process($command, $this->config->getProjectRootPath());
+        $process->run(function ($type, $buffer): void {
+            echo $buffer;
+        });
+
+        return $process->isSuccessful();
+    }
+
+    /**
+     * @param string $errorMessage
+     *
+     * @return void
+     */
+    protected function triggerError(string $errorMessage): void
+    {
+        trigger_error($errorMessage, E_USER_DEPRECATED);
+    }
+}

--- a/src/SprykerSdk/AsyncApi/AsyncApi/Cli/AsyncApiCliInterface.php
+++ b/src/SprykerSdk/AsyncApi/AsyncApi/Cli/AsyncApiCliInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\AsyncApi\AsyncApi\Cli;
+
+use Transfer\ValidateResponseTransfer;
+
+interface AsyncApiCliInterface
+{
+    /**
+     * @param \Transfer\ValidateResponseTransfer $validateResponseTransfer
+     * @param string $asyncApiFilePath
+     *
+     * @return \Transfer\ValidateResponseTransfer
+     */
+    public function validate(ValidateResponseTransfer $validateResponseTransfer, string $asyncApiFilePath): ValidateResponseTransfer;
+}

--- a/src/SprykerSdk/AsyncApi/AsyncApiConfig.php
+++ b/src/SprykerSdk/AsyncApi/AsyncApiConfig.php
@@ -31,8 +31,6 @@ class AsyncApiConfig
     /**
      * @api
      *
-     * @throws \SprykerSdk\AsyncApi\Exception\AsyncApiException
-     *
      * @return string
      */
     public function getProjectRootPath(): string

--- a/src/SprykerSdk/AsyncApi/AsyncApiFactory.php
+++ b/src/SprykerSdk/AsyncApi/AsyncApiFactory.php
@@ -7,6 +7,8 @@
 
 namespace SprykerSdk\AsyncApi;
 
+use SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCli;
+use SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCliInterface;
 use SprykerSdk\AsyncApi\AsyncApi\Loader\AsyncApiLoader;
 use SprykerSdk\AsyncApi\AsyncApi\Loader\AsyncApiLoaderInterface;
 use SprykerSdk\AsyncApi\Code\Builder\AsyncApiBuilder;
@@ -72,6 +74,7 @@ class AsyncApiFactory
         return new AsyncApiValidator(
             $this->getConfig(),
             $this->createMessageBuilder(),
+            $this->createAsyncApiCli(),
             $this->getAsyncApiValidatorRules(),
         );
     }
@@ -118,5 +121,13 @@ class AsyncApiFactory
     public function createMessageBuilder(): MessageBuilderInterface
     {
         return new MessageBuilder();
+    }
+
+    /**
+     * @return \SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCliInterface
+     */
+    public function createAsyncApiCli(): AsyncApiCliInterface
+    {
+        return new AsyncApiCli($this->getConfig(), $this->createMessageBuilder());
     }
 }

--- a/src/SprykerSdk/AsyncApi/Code/Builder/AsyncApiBuilder.php
+++ b/src/SprykerSdk/AsyncApi/Code/Builder/AsyncApiBuilder.php
@@ -266,7 +266,7 @@ class AsyncApiBuilder implements AsyncApiBuilderInterface
         }
 
         if ($asyncApiMessageTransfer->getIsSubscribe()) {
-            $asyncApi = $this->addMessageToChannelType($asyncApi, $messageName, $channelName, 'subscribe');
+            return $this->addMessageToChannelType($asyncApi, $messageName, $channelName, 'subscribe');
         }
 
         return $asyncApi;

--- a/src/SprykerSdk/AsyncApi/Console/SchemaMessageAddConsole.php
+++ b/src/SprykerSdk/AsyncApi/Console/SchemaMessageAddConsole.php
@@ -103,7 +103,7 @@ class SchemaMessageAddConsole extends AbstractConsole
             ->setDescription('Adds a message definition to a specified Async API schema file.')
             ->addArgument(static::ARGUMENT_CHANNEL_NAME, InputArgument::REQUIRED, 'The channel name to which the message should be sent.')
             ->addArgument(static::ARGUMENT_MESSAGE_NAME, InputOption::VALUE_REQUIRED, 'Name of the message e.g ProductUpdated.')
-            ->addArgument(static::ARGUMENT_MODULE_NAME, InputOption::VALUE_REQUIRED, 'The module name that will work with the message.')
+            ->addArgument(static::ARGUMENT_MODULE_NAME, InputOption::VALUE_REQUIRED, 'The module name that will be used to send or receive the message.')
             ->addOption(static::OPTION_ASYNC_API_FILE, static::OPTION_ASYNC_API_FILE_SHORT, InputOption::VALUE_REQUIRED, '', $this->getConfig()->getDefaultAsyncApiFile())
             ->addOption(static::OPTION_PROPERTY, static::OPTION_PROPERTY_SHORT, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'When this option is set the property value will be added to the message definition of the specified channel. Format: propertyName:propertyType. Example: -P firstName:string')
             ->addOption(static::OPTION_FROM_TRANSFER_CLASS, static::OPTION_FROM_TRANSFER_CLASS_SHORT, InputOption::VALUE_REQUIRED, 'The Transfer class name from which the message should be created.')

--- a/src/SprykerSdk/AsyncApi/Message/AbstractAsyncApiMessage.php
+++ b/src/SprykerSdk/AsyncApi/Message/AbstractAsyncApiMessage.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\AsyncApi\Message;
+
+class AbstractAsyncApiMessage
+{
+    protected static ?bool $isWindows = null;
+
+    /**
+     * @param bool|null $isWindows
+     */
+    public function __construct(?bool $isWindows = null)
+    {
+        static::$isWindows = $isWindows ?? stripos(PHP_OS, 'WIN') !== false;
+    }
+}

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
@@ -20,14 +20,6 @@ class AsyncApiError extends AbstractAsyncApiMessage
     protected const CODE_GENERATION_ERROR_PREFIX = 'AsyncAPI code generation error';
 
     /**
-     * @param bool|null $isWindows
-     */
-    public function __construct(?bool $isWindows = null)
-    {
-        parent::__construct($isWindows);
-    }
-
-    /**
      * @param string $path
      *
      * @return string

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
@@ -7,7 +7,7 @@
 
 namespace SprykerSdk\AsyncApi\Message;
 
-class AsyncApiError
+class AsyncApiError extends AbstractAsyncApiMessage
 {
     /**
      * @var string
@@ -19,14 +19,12 @@ class AsyncApiError
      */
     protected const CODE_GENERATION_ERROR_PREFIX = 'AsyncAPI code generation error';
 
-    protected static ?bool $isNotWindows = null;
-
     /**
-     * @param bool|null $isNotWindows
+     * @param bool|null $isWindows
      */
-    public function __construct(?bool $isNotWindows = null)
+    public function __construct(?bool $isWindows = null)
     {
-        static::$isNotWindows = $isNotWindows ?? (PHP_SAPI === PHP_SAPI && stripos(PHP_OS, 'WIN') === false);
+        parent::__construct($isWindows);
     }
 
     /**
@@ -228,7 +226,7 @@ class AsyncApiError
      */
     protected static function format(string $message): string
     {
-        if (static::$isNotWindows) {
+        if (!static::$isWindows) {
             return "\033[31m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
                     return sprintf("\033[0m\033[33m%s\033[0m\033[31m", $matches[1]);
             }, $message);

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
@@ -203,6 +203,21 @@ class AsyncApiError
     }
 
     /**
+     * @param string $path
+     *
+     * @return string
+     */
+    public static function asyncApiCliValidationFailed(string $path): string
+    {
+        return static::format(
+            sprintf(
+                'AsyncAPI CLI failed to validate schema "%s".',
+                $path,
+            ),
+        );
+    }
+
+    /**
      * Colorize output in CLI on Linux machines.
      *
      * Error text will be in red, everything in double quotes will be yellow, and quotes will be removed.

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
@@ -204,7 +204,7 @@ class AsyncApiError
     protected static function format(string $message): string
     {
         if (PHP_SAPI === PHP_SAPI && stripos(PHP_OS, 'WIN') === false) {
-            $message = "\033[31m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
+            return "\033[31m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
                     return sprintf("\033[0m\033[33m%s\033[0m\033[31m", $matches[1]);
             }, $message);
         }

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
@@ -19,6 +19,13 @@ class AsyncApiError
      */
     protected const CODE_GENERATION_ERROR_PREFIX = 'AsyncAPI code generation error';
 
+    protected static ?bool $isNotWindows = null;
+
+    public function __construct(?bool $isNotWindows = null)
+    {
+        static::$isNotWindows = $isNotWindows ?? stripos(PHP_OS, 'WIN') === false;
+    }
+
     /**
      * @param string $path
      *
@@ -203,7 +210,7 @@ class AsyncApiError
      */
     protected static function format(string $message): string
     {
-        if (PHP_SAPI === PHP_SAPI && stripos(PHP_OS, 'WIN') === false) {
+        if (static::$isNotWindows) {
             return "\033[31m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
                     return sprintf("\033[0m\033[33m%s\033[0m\033[31m", $matches[1]);
             }, $message);

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiError.php
@@ -21,9 +21,12 @@ class AsyncApiError
 
     protected static ?bool $isNotWindows = null;
 
+    /**
+     * @param bool|null $isNotWindows
+     */
     public function __construct(?bool $isNotWindows = null)
     {
-        static::$isNotWindows = $isNotWindows ?? stripos(PHP_OS, 'WIN') === false;
+        static::$isNotWindows = $isNotWindows ?? (PHP_SAPI === PHP_SAPI && stripos(PHP_OS, 'WIN') === false);
     }
 
     /**

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
@@ -9,6 +9,13 @@ namespace SprykerSdk\AsyncApi\Message;
 
 class AsyncApiInfo
 {
+    protected static ?bool $isNotWindows = null;
+
+    public function __construct(?bool $isNotWindows = null)
+    {
+        static::$isNotWindows = $isNotWindows ?? stripos(PHP_OS, 'WIN') === false ;
+    }
+
     /**
      * @return string
      */
@@ -102,7 +109,7 @@ class AsyncApiInfo
      */
     protected static function format(string $message): string
     {
-        if (PHP_SAPI === PHP_SAPI && stripos(PHP_OS, 'WIN') === false) {
+        if (static::$isNotWindows) {
             return "\033[32m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
                 return sprintf("\033[0m\033[33m%s\033[0m\033[32m", $matches[1]);
             }, $message);

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
@@ -7,16 +7,14 @@
 
 namespace SprykerSdk\AsyncApi\Message;
 
-class AsyncApiInfo
+class AsyncApiInfo extends AbstractAsyncApiMessage
 {
-    protected static ?bool $isNotWindows = null;
-
     /**
-     * @param bool|null $isNotWindows
+     * @param bool|null $isWindows
      */
-    public function __construct(?bool $isNotWindows = null)
+    public function __construct(?bool $isWindows = null)
     {
-        static::$isNotWindows = $isNotWindows ?? stripos(PHP_OS, 'WIN') === false;
+        parent::__construct($isWindows);
     }
 
     /**
@@ -126,7 +124,7 @@ class AsyncApiInfo
      */
     protected static function format(string $message): string
     {
-        if (static::$isNotWindows) {
+        if (!static::$isWindows) {
             return "\033[32m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
                 return sprintf("\033[0m\033[33m%s\033[0m\033[32m", $matches[1]);
             }, $message);

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
@@ -11,9 +11,12 @@ class AsyncApiInfo
 {
     protected static ?bool $isNotWindows = null;
 
+    /**
+     * @param bool|null $isNotWindows
+     */
     public function __construct(?bool $isNotWindows = null)
     {
-        static::$isNotWindows = $isNotWindows ?? stripos(PHP_OS, 'WIN') === false ;
+        static::$isNotWindows = $isNotWindows ?? stripos(PHP_OS, 'WIN') === false;
     }
 
     /**

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
@@ -102,6 +102,20 @@ class AsyncApiInfo
     }
 
     /**
+     * @return string
+     */
+    public static function asyncApiCliNotFound(): string
+    {
+        return static::format(
+            sprintf(
+                'AsyncAPI cli not found in your system, please make sure to install the "%s" package. More info at "%s".',
+                '@asyncapi/cli',
+                'https://www.asyncapi.com/docs/tools/cli/installation',
+            ),
+        );
+    }
+
+    /**
      * Colorize output in CLI on Linux machines.
      *
      * Info text will be in green, everything in double quotes will be yellow, and quotes will be removed.

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
@@ -103,7 +103,7 @@ class AsyncApiInfo
     protected static function format(string $message): string
     {
         if (PHP_SAPI === PHP_SAPI && stripos(PHP_OS, 'WIN') === false) {
-            $message = "\033[32m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
+            return "\033[32m" . preg_replace_callback('/"(.+?)"/', function (array $matches) {
                 return sprintf("\033[0m\033[33m%s\033[0m\033[32m", $matches[1]);
             }, $message);
         }

--- a/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
+++ b/src/SprykerSdk/AsyncApi/Message/AsyncApiInfo.php
@@ -10,14 +10,6 @@ namespace SprykerSdk\AsyncApi\Message;
 class AsyncApiInfo extends AbstractAsyncApiMessage
 {
     /**
-     * @param bool|null $isWindows
-     */
-    public function __construct(?bool $isWindows = null)
-    {
-        parent::__construct($isWindows);
-    }
-
-    /**
      * @return string
      */
     public static function asyncApiSchemaFileIsValid(): string

--- a/src/SprykerSdk/AsyncApi/Validator/AsyncApiValidator.php
+++ b/src/SprykerSdk/AsyncApi/Validator/AsyncApiValidator.php
@@ -8,6 +8,7 @@
 namespace SprykerSdk\AsyncApi\Validator;
 
 use Exception;
+use SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCliInterface;
 use SprykerSdk\AsyncApi\AsyncApiConfig;
 use SprykerSdk\AsyncApi\Message\AsyncApiError;
 use SprykerSdk\AsyncApi\Message\AsyncApiInfo;
@@ -34,15 +35,22 @@ class AsyncApiValidator implements ValidatorInterface
     protected array $validatorRules;
 
     /**
+     * @var \SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCliInterface
+     */
+    protected AsyncApiCliInterface $asyncApiCli;
+
+    /**
      * @param \SprykerSdk\AsyncApi\AsyncApiConfig $config
      * @param \SprykerSdk\AsyncApi\Message\MessageBuilderInterface $messageBuilder
+     * @param \SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCliInterface $asyncApiCli
      * @param array<\SprykerSdk\AsyncApi\Validator\Rule\ValidatorRuleInterface> $validatorRules
      */
-    public function __construct(AsyncApiConfig $config, MessageBuilderInterface $messageBuilder, array $validatorRules = [])
+    public function __construct(AsyncApiConfig $config, MessageBuilderInterface $messageBuilder, AsyncApiCliInterface $asyncApiCli, array $validatorRules = [])
     {
         $this->config = $config;
         $this->messageBuilder = $messageBuilder;
         $this->validatorRules = $validatorRules;
+        $this->asyncApiCli = $asyncApiCli;
     }
 
     /**
@@ -77,6 +85,8 @@ class AsyncApiValidator implements ValidatorInterface
         }
 
         $validateResponseTransfer = $this->executeValidatorRules($asyncApi, $asyncApiFile, $validateResponseTransfer);
+
+        $validateResponseTransfer = $this->asyncApiCli->validate($validateResponseTransfer, $asyncApiFile);
 
         if ($validateResponseTransfer->getErrors()->count() === 0) {
             $validateResponseTransfer->addMessage($this->messageBuilder->buildMessage(AsyncApiInfo::asyncApiSchemaFileIsValid()));

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Cli/AsyncApiCliTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Cli/AsyncApiCliTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\AsyncApi\AsyncApi\Cli;
+
+use Codeception\Test\Unit;
+use SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCli;
+use SprykerSdk\AsyncApi\AsyncApiConfig;
+use SprykerSdk\AsyncApi\Message\AsyncApiError;
+use SprykerSdk\AsyncApi\Message\AsyncApiInfo;
+use SprykerSdk\AsyncApi\Message\MessageBuilder;
+use SprykerSdkTest\AsyncApi\AsyncApiTester;
+use Transfer\ValidateResponseTransfer;
+
+/**
+ * @group SprykerSdkTest
+ * @group AsyncApi
+ * @group AsyncApiCli
+ * @group AsyncApiCliTest
+ */
+class AsyncApiCliTest extends Unit
+{
+    /**
+     * @var \SprykerSdkTest\AsyncApi\AsyncApiTester
+     */
+    protected AsyncApiTester $tester;
+
+    /**
+     * @return void
+     */
+    public function testNoAsyncApiInstalledWhenIRunTheValidationThenISeeAMessageWithInstallInstructions()
+    {
+        // Arrange
+        $asyncApiCliMock = $this->getAsyncApiCliMock(['runProcess']);
+        $asyncApiCliMock->method('runProcess')->willReturn(false);
+
+        // Act
+        $validateResponseTransfer = $asyncApiCliMock->validate((new ValidateResponseTransfer()), '/');
+
+        $validateResponseTransferMessages = $validateResponseTransfer->getMessages();
+
+        // Assert
+        $this->assertCount(1, $validateResponseTransferMessages);
+        $this->assertSame(AsyncApiInfo::asyncApiCliNotFound(), $validateResponseTransferMessages->offsetGet(0)->getMessage());
+    }
+
+    /**
+     * @return void
+     */
+    public function testAsyncApiIsInstalledWhenIRunTheValidationOnAnInvalidFileThenISeeAnErrorMessage()
+    {
+        // Arrange
+        $asyncApiCliMock = $this->getAsyncApiCliMock(['runProcess']);
+        $asyncApiCliMock->method('runProcess')->willReturnOnConsecutiveCalls(true, false);
+
+        // Act
+        $validateResponseTransfer = $asyncApiCliMock->validate((new ValidateResponseTransfer()), 'somePath');
+
+        $validateResponseTransferErrors = $validateResponseTransfer->getErrors();
+
+        // Assert
+        $this->assertCount(1, $validateResponseTransferErrors);
+        $this->assertSame(AsyncApiError::asyncApiCliValidationFailed('somePath'), $validateResponseTransferErrors->offsetGet(0)->getMessage());
+    }
+
+    /**
+     * @return void
+     */
+    public function testNoAsyncApiInstalledWhenIRunTheValidationTriggerDeprecationWarning()
+    {
+        // Arrange
+        $asyncApiCliMock = $this->getAsyncApiCliMock(['runProcess', 'triggerError']);
+        $asyncApiCliMock->method('runProcess')->willReturn(false);
+
+        // Expectation
+        $asyncApiCliMock->expects($this->once())->method('triggerError');
+
+        // Act
+        $asyncApiCliMock->validate((new ValidateResponseTransfer()), '/');
+    }
+
+    /**
+     * @return void
+     */
+    public function testAsyncApiIsInstalledWhenIRunTheValidationOnAnValidFileThenIDontSeeAnErrorMessage()
+    {
+        // Arrange
+        $asyncApiCliMock = $this->getAsyncApiCliMock(['runProcess']);
+        $asyncApiCliMock->method('runProcess')->willReturn(true);
+
+        // Act
+        $validateResponseTransfer = $asyncApiCliMock->validate((new ValidateResponseTransfer()), codecept_data_dir('api/valid/base_asyncapi.schema.yml'));
+
+        $validateResponseTransferErrors = $validateResponseTransfer->getErrors();
+
+        // Assert
+        $this->assertCount(0, $validateResponseTransferErrors);
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject|(\SprykerSdk\AsyncApi\AsyncApi\Cli\AsyncApiCli&\PHPUnit\Framework\MockObject\MockObject)
+     */
+    public function getAsyncApiCliMock(array $methods): AsyncApiCli|\PHPUnit\Framework\MockObject\MockObject
+    {
+        return $this->getMockBuilder(AsyncApiCli::class)->setConstructorArgs([new AsyncApiConfig(), new MessageBuilder()])->onlyMethods($methods)->getMock();
+    }
+}

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
@@ -34,7 +34,7 @@ class AsyncApiErrorTest extends Unit
      */
     public function testErrorMessageIsNotFormattedWhenOSIsWindows()
     {
-        $class = new AsyncApiError();
+        $class = new AsyncApiError(false);
         $message = $class::couldNotFindAModulePropertyInTheSprykerExtension(static::TEST_PATH);
 
         $this->assertNotNull($message);

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SprykerSdkTest\AsyncApi\AsyncApi\Message;
+
+use Codeception\Test\Unit;
+use SprykerSdk\AsyncApi\Message\AsyncApiError;
+
+class AsyncApiErrorTest extends Unit
+{
+    protected const TEST_PATH = 'test/path';
+
+    public function testErrorMessageIsFormattedWhenOSIsNotWindows()
+    {
+        $class = new AsyncApiError(true);
+        $message = $class::couldNotFindAModulePropertyInTheSprykerExtension(static::TEST_PATH);
+
+        $this->assertNotNull($message);
+        $this->assertStringContainsString('[', $message);
+    }
+
+    public function testErrorMessageIsNotFormattedWhenOSIsWindows()
+    {
+        $class = new AsyncApiError();
+        $message = $class::couldNotFindAModulePropertyInTheSprykerExtension(static::TEST_PATH);
+
+        $this->assertNotNull($message);
+        $this->assertStringNotContainsString('[', $message);
+    }
+}

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
@@ -22,7 +22,7 @@ class AsyncApiErrorTest extends Unit
      */
     public function testErrorMessageIsFormattedWhenOSIsNotWindows()
     {
-        $class = new AsyncApiError(true);
+        $class = new AsyncApiError(false);
         $message = $class::couldNotFindAModulePropertyInTheSprykerExtension(static::TEST_PATH);
 
         $this->assertNotNull($message);
@@ -34,7 +34,7 @@ class AsyncApiErrorTest extends Unit
      */
     public function testErrorMessageIsNotFormattedWhenOSIsWindows()
     {
-        $class = new AsyncApiError(false);
+        $class = new AsyncApiError(true);
         $message = $class::couldNotFindAModulePropertyInTheSprykerExtension(static::TEST_PATH);
 
         $this->assertNotNull($message);

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiErrorTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
 namespace SprykerSdkTest\AsyncApi\AsyncApi\Message;
 
 use Codeception\Test\Unit;
@@ -7,8 +12,14 @@ use SprykerSdk\AsyncApi\Message\AsyncApiError;
 
 class AsyncApiErrorTest extends Unit
 {
+    /**
+     * @var string
+     */
     protected const TEST_PATH = 'test/path';
 
+    /**
+     * @return void
+     */
     public function testErrorMessageIsFormattedWhenOSIsNotWindows()
     {
         $class = new AsyncApiError(true);
@@ -18,6 +29,9 @@ class AsyncApiErrorTest extends Unit
         $this->assertStringContainsString('[', $message);
     }
 
+    /**
+     * @return void
+     */
     public function testErrorMessageIsNotFormattedWhenOSIsWindows()
     {
         $class = new AsyncApiError();

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
@@ -29,7 +29,7 @@ class AsyncApiInfoTest extends Unit
      */
     public function testInfoMessageIsNotFormattedWhenOSIsWindows()
     {
-        $class = new AsyncApiInfo();
+        $class = new AsyncApiInfo(false);
         $message = $class::asyncApiSchemaFileIsValid();
 
         $this->assertNotNull($message);

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
@@ -13,12 +13,17 @@ use SprykerSdk\AsyncApi\Message\AsyncApiInfo;
 class AsyncApiInfoTest extends Unit
 {
     /**
+     * @var string
+     */
+    protected const TEST_FILE_NAME = 'fileName';
+
+    /**
      * @return void
      */
     public function testInfoMessageIsFormattedWhenOSIsNotWindows()
     {
         $class = new AsyncApiInfo(true);
-        $message = $class::asyncApiSchemaFileIsValid();
+        $message = $class::asyncApiFileCreated(static::TEST_FILE_NAME);
 
         $this->assertNotNull($message);
         $this->assertStringContainsString('[', $message);
@@ -30,7 +35,7 @@ class AsyncApiInfoTest extends Unit
     public function testInfoMessageIsNotFormattedWhenOSIsWindows()
     {
         $class = new AsyncApiInfo(false);
-        $message = $class::asyncApiSchemaFileIsValid();
+        $message = $class::asyncApiFileCreated(static::TEST_FILE_NAME);
 
         $this->assertNotNull($message);
         $this->assertStringNotContainsString('[', $message);

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SprykerSdkTest\AsyncApi\AsyncApi\Message;
+
+use Codeception\Test\Unit;
+use SprykerSdk\AsyncApi\Message\AsyncApiInfo;
+
+class AsyncApiInfoTest extends Unit
+{
+    public function testInfoMessageIsFormattedWhenOSIsNotWindows()
+    {
+        $class = new AsyncApiInfo(true);
+        $message = $class::asyncApiSchemaFileIsValid();
+
+        $this->assertNotNull($message);
+        $this->assertStringContainsString('[', $message);
+    }
+
+    public function testInfoMessageIsNotFormattedWhenOSIsWindows()
+    {
+        $class = new AsyncApiInfo();
+        $message = $class::asyncApiSchemaFileIsValid();
+
+        $this->assertNotNull($message);
+        $this->assertStringNotContainsString('[', $message);
+    }
+}

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
 namespace SprykerSdkTest\AsyncApi\AsyncApi\Message;
 
 use Codeception\Test\Unit;
@@ -7,6 +12,9 @@ use SprykerSdk\AsyncApi\Message\AsyncApiInfo;
 
 class AsyncApiInfoTest extends Unit
 {
+    /**
+     * @return void
+     */
     public function testInfoMessageIsFormattedWhenOSIsNotWindows()
     {
         $class = new AsyncApiInfo(true);
@@ -16,6 +24,9 @@ class AsyncApiInfoTest extends Unit
         $this->assertStringContainsString('[', $message);
     }
 
+    /**
+     * @return void
+     */
     public function testInfoMessageIsNotFormattedWhenOSIsWindows()
     {
         $class = new AsyncApiInfo();

--- a/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/AsyncApi/Message/AsyncApiInfoTest.php
@@ -22,7 +22,7 @@ class AsyncApiInfoTest extends Unit
      */
     public function testInfoMessageIsFormattedWhenOSIsNotWindows()
     {
-        $class = new AsyncApiInfo(true);
+        $class = new AsyncApiInfo(false);
         $message = $class::asyncApiFileCreated(static::TEST_FILE_NAME);
 
         $this->assertNotNull($message);
@@ -34,7 +34,7 @@ class AsyncApiInfoTest extends Unit
      */
     public function testInfoMessageIsNotFormattedWhenOSIsWindows()
     {
-        $class = new AsyncApiInfo(false);
+        $class = new AsyncApiInfo(true);
         $message = $class::asyncApiFileCreated(static::TEST_FILE_NAME);
 
         $this->assertNotNull($message);

--- a/tests/SprykerSdkTest/AsyncApi/Console/SchemaValidateConsoleTest.php
+++ b/tests/SprykerSdkTest/AsyncApi/Console/SchemaValidateConsoleTest.php
@@ -32,12 +32,10 @@ class SchemaValidateConsoleTest extends Unit
     public function testValidateAsyncApiReturnsSuccessCodeWhenValidationIsSuccessful(): void
     {
         // Arrange
-        $this->tester->haveValidAsyncApiFile();
-
         $commandTester = $this->tester->getConsoleTester(SchemaValidateConsole::class);
 
         // Act
-        $commandTester->execute([]);
+        $commandTester->execute(['--asyncapi-file' => codecept_data_dir('api/valid/base_asyncapi.schema.yml')]);
 
         // Assert
         $this->assertSame(AbstractConsole::CODE_SUCCESS, $commandTester->getStatusCode());

--- a/tests/_data/api/valid/base_asyncapi.schema.yml
+++ b/tests/_data/api/valid/base_asyncapi.schema.yml
@@ -5,7 +5,11 @@ info:
 channels:
     foo/bar:
         subscribe:
+            message:
+                $ref: '#/components/messages/message'
         publish:
+            message:
+                $ref: '#/components/messages/message'
 components:
     schemas:
         headers:


### PR DESCRIPTION
- Developer(s): @danielsantos-spryker 

- Ticket: https://spryker.atlassian.net/browse/PBC-1656

- Release Group: https://release.spryker.com/release-groups/view/4850

#### Release Table

| Module     | Release Type      | Constraint Updates |
|:-----------|:------------------|:-------------------|
| AsyncApi | minor |                    |

-----------------------------------------

#### Module AsyncApi

##### Change log

### Improvements
- Introduced `AsyncApi CLI` for schema validation according to AsyncApi specification.
- Updated help output for the `SchemaMessageAddConsole`.
